### PR TITLE
filteringの追加

### DIFF
--- a/back/app/controllers/api/tourist_spots_controller.rb
+++ b/back/app/controllers/api/tourist_spots_controller.rb
@@ -15,14 +15,28 @@ module Api
       response = Net::HTTP.get(url)
       data = JSON.parse(response)
 
-      # スポット情報を作成
-      spots = data['results'].each_with_index.map do |place, index|
+      results = data['results'] || []
+
+      # フィルタリング (評価4.0以上 & レビュー数50件以上)
+      filtered_results = results.select do |place|
+        place['rating'].to_f >= 4.0 && place['user_ratings_total'].to_i >= 50
+      end
+
+      # 人気順にソート (レビュー数 → 評価)
+      sorted_results = filtered_results.sort_by do |place|
+        [-place['user_ratings_total'].to_i, -place['rating'].to_f]
+      end
+
+      # 指定フォーマットに変換
+      spots = sorted_results.each_with_index.map do |place, index|
         {
           id: index + 1,
           name: place['name'],
-          description: "ここは #{place['name']} です。観光名所として有名です。",
+          description: "#{place['name']}は観光名所として知られています。",
           url: "https://www.google.com/maps/place/?q=place_id:#{place['place_id']}",
-          image: place['photos']&.first ? "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=#{place['photos'].first['photo_reference']}&key=#{api_key}" : "https://placehold.co/100x100/A0AEC0/ffffff?text=Image"
+          image: place['photos']&.first ?
+                   "https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=#{place['photos'].first['photo_reference']}&key=#{api_key}" :
+                   "https://placehold.co/100x100/A0AEC0/ffffff?text=Image"
         }
       end
 
@@ -30,3 +44,4 @@ module Api
     end
   end
 end
+

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -1,25 +1,25 @@
 Rails.application.routes.draw do
-  # セッション管理
-  post   "sessions", to: "sessions#create"   # ログイン
-  delete "sessions", to: "sessions#destroy"  # ログアウト
+  post   "sessions", to: "sessions#create" # ログイン処理(SessionsController#create)
+  delete "sessions", to: "sessions#destroy" # ログアウト処理(SessionsController#destroy)
 
-  # API（すべて JSON 固定）
-  namespace :api, defaults: { format: :json } do
-    # 動作確認
-    get "/ping", to: "ping#index"
+  namespace :api, defaults: { format: :json } do #front/src/app/test-apiの"http://localhost:3050/api/"
+    get :ping, to: "ping#index" #動作テスト部分(ping_controller.rbで何をフロントに送信するかを記述する)
 
-    # 記録関連
-    resources :adventure_records, only: [:create, :index]
+    resources :adventure_records, only: [:create, :index] #create:記録作成、index:記録一覧の取得
     get "total_record", to: "total_records#show"
-
-    # 記録ページ用
-    get "runs/stats", to: "runs#stats"
-    get "runs", to: "runs#index"
-
-    # ドライブ画面用
-    get "quests", to: "quests#index"
-    get "tourist_spots", to: "tourist_spots#index"
   end
+
+  
+  namespace :api do
+    # 記録ページ用
+    get "runs/stats", to: "runs#stats" # 集計（最新＋累計）
+    get "runs", to: "runs#index" # リスト表示用
+    # ドライブ中画面用
+    get "quests", to: "quests#index" # クエスト選択
+    get "/ping", to: "ping#index"
+    get "/tourist_spots", to: "tourist_spots#index"
+  end
+  
 end
 
 

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -1,26 +1,28 @@
 Rails.application.routes.draw do
-  post   "sessions", to: "sessions#create" # ログイン処理(SessionsController#create)
-  delete "sessions", to: "sessions#destroy" # ログアウト処理(SessionsController#destroy)
+  # セッション管理
+  post   "sessions", to: "sessions#create"   # ログイン
+  delete "sessions", to: "sessions#destroy"  # ログアウト
 
-  namespace :api, defaults: { format: :json } do #front/src/app/test-apiの"http://localhost:3050/api/"
-    get :ping, to: "ping#index" #動作テスト部分(ping_controller.rbで何をフロントに送信するかを記述する)
-
-    resources :adventure_records, only: [:create, :index] #create:記録作成、index:記録一覧の取得
-    get "total_record", to: "total_records#show"
-  end
-
-  
-  namespace :api do
-    # 記録ページ用
-    get "runs/stats", to: "runs#stats" # 集計（最新＋累計）
-    get "runs", to: "runs#index" # リスト表示用
-    # ドライブ中画面用
-    get "quests", to: "quests#index" # クエスト選択
+  # API グループ（すべてJSON）
+  namespace :api, defaults: { format: :json } do
+    
+    # 動作確認
     get "/ping", to: "ping#index"
+
+    # 記録関連
+    resources :adventure_records, only: [:create, :index]
+    get "total_record", to: "total_records#show"
+
+    # 記録ページ用
+    get "runs/stats", to: "runs#stats"
+    get "runs", to: "runs#index"
+
+    # ドライブ画面用
+    get "quests", to: "quests#index"
     get "/tourist_spots", to: "tourist_spots#index"
   end
-  
 end
+
 
 
 

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -3,9 +3,8 @@ Rails.application.routes.draw do
   post   "sessions", to: "sessions#create"   # ログイン
   delete "sessions", to: "sessions#destroy"  # ログアウト
 
-  # API グループ（すべてJSON）
+  # API（すべて JSON 固定）
   namespace :api, defaults: { format: :json } do
-    
     # 動作確認
     get "/ping", to: "ping#index"
 
@@ -19,10 +18,9 @@ Rails.application.routes.draw do
 
     # ドライブ画面用
     get "quests", to: "quests#index"
-    get "/tourist_spots", to: "tourist_spots#index"
+    get "tourist_spots", to: "tourist_spots#index"
   end
 end
-
 
 
 


### PR DESCRIPTION
## 概要
観光地取得APIで返ってくる場所の中に、観光地っぽくないものや知名度が低い場所が混ざることがあったため、以下の条件でフィルタリングとソートを追加しました。

- 評価（rating）が 4.0 以上
- レビュー数（user_ratings_total）が 50 件以上
- フィルタリング後、レビュー数の多い順 → 評価の高い順にソート
（地方部だとレビューが少ない場合もあるので50件にしています）
これにより、有名で人気のある観光地を優先的に返すことができます。

## 変更内容
- `TouristSpotsController#index` 内でフィルタリング & ソート処理を追加
- 返却フォーマットは既存の `{id, name, description, url, image}` に準拠

